### PR TITLE
Add missing exit codes

### DIFF
--- a/Command/DeleteCommand.php
+++ b/Command/DeleteCommand.php
@@ -26,7 +26,7 @@ class DeleteCommand extends ConsumerCommand
      * @param InputInterface $input
      * @param OutputInterface $output
      *
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Command/DeleteCommand.php
+++ b/Command/DeleteCommand.php
@@ -51,5 +51,7 @@ class DeleteCommand extends ConsumerCommand
         $this->consumer = $this->getContainer()
             ->get(sprintf($this->getConsumerService(), $input->getArgument('name')));
         $this->consumer->delete();
+
+        return 0;
     }
 }

--- a/Command/PurgeConsumerCommand.php
+++ b/Command/PurgeConsumerCommand.php
@@ -26,7 +26,7 @@ class PurgeConsumerCommand extends ConsumerCommand
      * @param InputInterface $input
      * @param OutputInterface $output
      *
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Command/PurgeConsumerCommand.php
+++ b/Command/PurgeConsumerCommand.php
@@ -51,5 +51,7 @@ class PurgeConsumerCommand extends ConsumerCommand
         $this->consumer = $this->getContainer()
             ->get(sprintf($this->getConsumerService(), $input->getArgument('name')));
         $this->consumer->purge($input->getArgument('name'));
+
+        return 0;
     }
 }

--- a/RabbitMq/BatchConsumer.php
+++ b/RabbitMq/BatchConsumer.php
@@ -126,6 +126,8 @@ class BatchConsumer extends BaseAmqp implements DequeuerInterface
                 }
             }
         }
+
+        return 0;
     }
 
     private function batchConsume()


### PR DESCRIPTION
By using this bundle with symfony 5, I stumbled across some missing exit codes.

Symfony deprecated returning `null` from `Command::execute` with v4.4 and removed the support with v5.0, see https://github.com/symfony/symfony/commit/98c4f6a06ce6b04e17b72329522868d9646ce3dd for more details.

I checked the other commands and consumers and I hope I found them all. :sweat_smile: 