### PR TITLE
Added new arguments parameter in queueBind() method for MultipleConsu…

### DIFF
--- a/RabbitMq/MultipleConsumer.php
+++ b/RabbitMq/MultipleConsumer.php
@@ -80,10 +80,10 @@ class MultipleConsumer extends Consumer
 
             if (isset($options['routing_keys']) && count($options['routing_keys']) > 0) {
                 foreach ($options['routing_keys'] as $routingKey) {
-                    $this->queueBind($queueName, $this->exchangeOptions['name'], $routingKey);
+                    $this->queueBind($queueName, $this->exchangeOptions['name'], $routingKey, $options['arguments'] ?? []);
                 }
             } else {
-                $this->queueBind($queueName, $this->exchangeOptions['name'], $this->routingKey);
+                $this->queueBind($queueName, $this->exchangeOptions['name'], $this->routingKey, $options['arguments'] ?? []);
             }
         }
 


### PR DESCRIPTION
…mers.

Add the same logic done in this [pull request](https://github.com/eMAGTechLabs/RabbitMqBundle/pull/32) for the multiple consumers class. Cannot push a new branch to your repo, so used a fork.

Linked to issue: [issue strict header binding](https://github.com/eMAGTechLabs/RabbitMqBundle/issues/30)