### PR TITLE
Add PHP 8 support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,7 @@
 build:
+    dependencies:
+        before:
+            - composer config minimum-stability RC
     nodes:
         analysis:
             tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,15 @@ matrix:
       env: SYMFONY_VERSION=^5.0
     - php: 7.4
       env: SYMFONY_VERSION=^5.0
+    - php: 8.0
+      env: SYMFONY_VERSION=^5.0 MINIMUM_STABILITY=RC
 
   allow_failures:
     - php: nightly
 
 before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle "$SYMFONY_VERSION"; fi
+  - if [ "$MINIMUM_STABILITY" != "" ]; then composer config minimum-stability "$MINIMUM_STABILITY"; fi
   - if [ "$COMPOSER_FLAGS" != "" ]; then composer update --prefer-dist --no-interaction --no-scripts $COMPOSER_FLAGS; fi;
 
 install:

--- a/Resources/config/rabbitmq.xml
+++ b/Resources/config/rabbitmq.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="old_sound_rabbit_mq.connection.class">PhpAmqpLib\Connection\AMQPConnection</parameter>
+        <parameter key="old_sound_rabbit_mq.connection.class">PhpAmqpLib\Connection\AMQPStreamConnection</parameter>
         <parameter key="old_sound_rabbit_mq.socket_connection.class">PhpAmqpLib\Connection\AMQPSocketConnection</parameter>
         <parameter key="old_sound_rabbit_mq.lazy.connection.class">PhpAmqpLib\Connection\AMQPLazyConnection</parameter>
         <parameter key="old_sound_rabbit_mq.lazy.socket_connection.class">PhpAmqpLib\Connection\AMQPLazySocketConnection</parameter>

--- a/Tests/Event/AfterProcessingMessageEventTest.php
+++ b/Tests/Event/AfterProcessingMessageEventTest.php
@@ -17,7 +17,7 @@ class AfterProcessingMessageEventTest extends TestCase
     protected function getConsumer()
     {
         return new Consumer(
-            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
                 ->disableOriginalConstructor()
                 ->getMock(),
             $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')

--- a/Tests/Event/BeforeProcessingMessageEventTest.php
+++ b/Tests/Event/BeforeProcessingMessageEventTest.php
@@ -17,7 +17,7 @@ class BeforeProcessingMessageEventTest extends TestCase
     protected function getConsumer()
     {
         return new Consumer(
-            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
                 ->disableOriginalConstructor()
                 ->getMock(),
             $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')

--- a/Tests/Event/OnIdleEventTest.php
+++ b/Tests/Event/OnIdleEventTest.php
@@ -16,7 +16,7 @@ class OnIdleEventTest extends TestCase
     protected function getConsumer()
     {
         return new Consumer(
-            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+            $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
                 ->disableOriginalConstructor()
                 ->getMock(),
             $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')

--- a/Tests/RabbitMq/BaseConsumerTest.php
+++ b/Tests/RabbitMq/BaseConsumerTest.php
@@ -12,7 +12,7 @@ class BaseConsumerTest extends TestCase
 
     protected function setUp(): void
     {
-        $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+        $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/RabbitMq/BindingTest.php
+++ b/Tests/RabbitMq/BindingTest.php
@@ -20,7 +20,7 @@ class BindingTest extends TestCase
      */
     protected function prepareAMQPConnection()
     {
-        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/RabbitMq/ConsumerTest.php
+++ b/Tests/RabbitMq/ConsumerTest.php
@@ -8,7 +8,7 @@ use OldSound\RabbitMqBundle\Event\OnConsumeEvent;
 use OldSound\RabbitMqBundle\Event\OnIdleEvent;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
@@ -26,7 +26,7 @@ class ConsumerTest extends TestCase
 
     protected function prepareAMQPConnection()
     {
-        return $this->getMockBuilder(AMQPConnection::class)
+        return $this->getMockBuilder(AMQPStreamConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/RabbitMq/MultipleConsumerTest.php
+++ b/Tests/RabbitMq/MultipleConsumerTest.php
@@ -6,7 +6,7 @@ use OldSound\RabbitMqBundle\Provider\QueuesProviderInterface;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -31,7 +31,7 @@ class MultipleConsumerTest extends TestCase
     /**
      * AMQP connection
      *
-     * @var MockObject|AMQPConnection
+     * @var MockObject|AMQPStreamConnection
      */
     private $amqpConnection;
 
@@ -255,11 +255,11 @@ class MultipleConsumerTest extends TestCase
     /**
      * Preparing AMQP Connection
      *
-     * @return MockObject|AMQPConnection
+     * @return MockObject|AMQPStreamConnection
      */
     private function prepareAMQPConnection()
     {
-        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+        return $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,14 @@
         "name" : "Alvaro Videla"
     }],
     "require": {
-        "php":                          "^7.1",
+        "php":                          "^7.1|^8.0",
 
         "symfony/dependency-injection": "^4.3|^5.0",
         "symfony/event-dispatcher":     "^4.3|^5.0",
         "symfony/config":               "^4.3|^5.0",
         "symfony/yaml":                 "^4.3|^5.0",
         "symfony/console":              "^4.3|^5.0",
-        "php-amqplib/php-amqplib":      "^2.6",
+        "php-amqplib/php-amqplib":      "^2.6|^3.0",
         "psr/log":                      "^1.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0"


### PR DESCRIPTION
We already have 2 release candidates of the new major version of php-amqplib which supports PHP 8: https://github.com/php-amqplib/php-amqplib/releases

This PR adds PHP 8 support using `php-amqplib/php-amqplib:^3.0`

Fixes #40